### PR TITLE
Url security update

### DIFF
--- a/lib/antinode.js
+++ b/lib/antinode.js
@@ -87,7 +87,7 @@ function map_request_to_local_file(req, resp) {
     //if the parsed url doesn't have a pathname, default to '/'
     var pathname = (url.pathname || '/');
     var clean_pathname = pathname.
-        replace(/\.\.\//g,''). //disallow parent directory access
+        replace(/\.\.\.*\/\/*/g,''). //disallow parent directory access
             replace(/\%20/g,' ');  //convert spaces
 
     function select_vhost() {

--- a/tests/test-path-security.js
+++ b/tests/test-path-security.js
@@ -1,0 +1,18 @@
+require('./common');
+
+exports["don't allow access to files outside of basedir"] = function (test) {
+    antinode.start(settings, function() {
+        test_http(test, {
+                      'method':'GET',
+                      'pathname':'/....//scripthost.js',
+                      'headers': { 'host' : 'default-host' }
+                    }, {
+                      'statusCode': 404,
+                      'body':''
+                    },
+          function () {
+              antinode.stop();
+              test.done();
+        });
+    });
+};


### PR DESCRIPTION
Hi Mark,

I found an issue with antinode where you could craft a url that would allow parent directory access. The regex used to prevent this would turn this string: '/....//secret' into : '/../secret'. 

This is has a fix for that as well as a unit test.

-psanford
