### PR TITLE
U8name

### DIFF
--- a/lib/antinode.js
+++ b/lib/antinode.js
@@ -86,9 +86,9 @@ function map_request_to_local_file(req, resp) {
     var url = uri.parse(req.url);
     //if the parsed url doesn't have a pathname, default to '/'
     var pathname = (url.pathname || '/');
-    var clean_pathname = pathname.
-        replace(/\.\.\.*\/\/*/g,''). //disallow parent directory access
-            replace(/\%20/g,' ');  //convert spaces
+    var clean_pathname = decodeURIComponent(
+            //disallow parent directory access
+            pathname.replace(/\.\.\.*\/\/*/g,''))
 
     function select_vhost() {
         if (req.headers.host) {


### PR DESCRIPTION
Hi, Mark.

I'm starting to play with NodeJS and want to try switching from Yaws to antinode for a dozen of my sites, all served on the same machine.  (The .sjs machinery has also been convenient for replacing bits of Python here).

However, antinode was unable to deliver files using characters outside pure ASCII, while I have of these, and had for many years.  The small patch I propose works for me.  Would you consider it?

I'm all UTF-8 here, and this is also the default or preferred NodeJS charset, so far that I saw (I'm still new to this).  Maybe the patch might be inadequate for other charsets however, I do not know enough to propose something more general.

I'll experiment a bit more at home.  If all goes well, I'll push this into production.  Do you advise against this?

Keep happy, and thanks for sharing antinode with us all! ☺
