### PR TITLE
support for omitting extensions

### DIFF
--- a/lib/antinode.js
+++ b/lib/antinode.js
@@ -111,7 +111,25 @@ function map_request_to_local_file(req, resp) {
             return;
         }
     } 
+
     var path = pathlib.join(vhost.root, clean_pathname);
+
+    function exists(path) {
+        try { return fs.statSync(path); }
+        catch(ex) { return false; }
+    }
+
+    if(settings.file_extensions && !exists(path)) {
+        var extensions = settings.file_extensions;
+        for(var ext_index = 0; ext_index < extensions.length; ext_index++) {
+            var ext = extensions[ext_index];
+            if(exists(path + ext)) {
+                path += ext;
+                break;
+            }
+        }
+    }
+
     if (path.match(/\.sjs$/)) {
         execute_sjs(path, req, resp);
     } else {

--- a/lib/antinode.js
+++ b/lib/antinode.js
@@ -114,13 +114,14 @@ function map_request_to_local_file(req, resp) {
 
     var path = pathlib.join(vhost.root, clean_pathname);
 
-    function exists(path) {
-        try { return fs.statSync(path); }
-        catch(ex) { return false; }
-    }
+    var extensions = settings.file_extensions;
 
-    if(settings.file_extensions && !exists(path)) {
-        var extensions = settings.file_extensions;
+    if(extensions && !exists(path)) {
+        function exists(path) {
+            try { return fs.statSync(path); }
+            catch(ex) { return false; }
+        }
+
         for(var ext_index = 0; ext_index < extensions.length; ext_index++) {
             var ext = extensions[ext_index];
             if(exists(path + ext)) {


### PR DESCRIPTION
Hi

I added support for the key "file_extentions" to settings.js
If specified, and a file is not found, the path + each extension will be tried until a file is found.

It uses fs.statSync, so it's not very fast, but it's optional, so whatever.

```
             -Adam
```
