### PR TITLE
Redirection from directory to index.html broken on Windows (node.js issue)

### DIFF
--- a/lib/antinode.js
+++ b/lib/antinode.js
@@ -142,9 +142,11 @@ function serve_static_file(path, req, resp) {
                 // any other error is abnormal - log it
                 log.error("fs.stat(",path,") failed: ", err);
             }
-            return file_not_found();
+            if (path.substr(-1) != '\\') { // Node for Windows compatibility hack (fs.stat fails on folders)
+                return file_not_found();
+            }
         }
-        if (stats.isDirectory()) {
+        if (stats == undefined || stats.isDirectory()) {
             var parsed_url = uri.parse(req.url);
             if (parsed_url.pathname.match(/\/$/)) {
                 return serve_static_file(pathlib.join(path, "index.html"), req, resp);


### PR DESCRIPTION
This patch hacks a Windows-specific problem, caused by some node builds (mine is 0.5.1): since fs.stat seems to always fail on folders, it breaks the fetching of index.html when the URL asks for a folder.

I post this here in case other Windows users get the same issue, rather than to be merged to master.
